### PR TITLE
Don't force WINDOWS-1252 encoding for Natural Earth

### DIFF
--- a/external-data.yml
+++ b/external-data.yml
@@ -38,9 +38,6 @@ sources:
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/physical/ne_50m_ocean.zip
     file: ne_50m_ocean.shp
     ogropts: &ne_opts
-      - "--config"
-      - "SHAPE_ENCODING"
-      - "WINDOWS-1252"
       - "-explodecollections"
       # needs reprojecting
       - '-t_srs'


### PR DESCRIPTION
This used to be required, but now causes errors.

Bug: https://phabricator.wikimedia.org/T192850